### PR TITLE
Ignore .vs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ build/
 [Bb]in/
 [Oo]bj/
 
+# Visual Studio 2015 cache/options directory
+.vs/
+
 # Enable "build/" folder in the NuGet Packages folder since NuGet packages use it for MSBuild targets
 !packages/*/build/
 


### PR DESCRIPTION
As of Visual Studio 2015 CTP5 the Roslyn cache and suo files are stored in a .vs/ directory.
